### PR TITLE
Improved base

### DIFF
--- a/JavaScript/JQuery.hs
+++ b/JavaScript/JQuery.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE ForeignFunctionInterface, EmptyDataDecls, OverloadedStrings, DeriveGeneric, DeriveDataTypeable #-}
+{-# LANGUAGE ExtendedDefaultRules #-}
 
 {-
   JQuery bindings, loosely based on fay-jquery
@@ -184,14 +185,18 @@ module JavaScript.JQuery ( JQuery(..)
                          , slice
                          , sliceFromTo
                          , stop
+
                          ) where
 
 import           Prelude hiding (filter, not, empty, last)
 
 import           GHCJS.Marshal
-import           GHCJS.Foreign ( ToJSString(..), FromJSString(..), newObj
-                               , toJSBool, jsNull, jsFalse, jsTrue, mvarRef
+import           GHCJS.Foreign ( toJSBool, jsNull, jsFalse, jsTrue
                                )
+import           GHCJS.Foreign.Callback as Cb
+import           GHCJS.Types (jsref)
+import           JavaScript.Object as Obj (Object, create, getProp, setProp)
+import           JavaScript.Cast as J (cast)
 import           GHCJS.Types
 import           GHCJS.DOM.Types (Element(..), IsElement(..), toElement
                                  , unElement)
@@ -204,12 +209,21 @@ import           Control.Concurrent
 import           Control.Concurrent.MVar
 import           Control.Monad
 
+import           Unsafe.Coerce (unsafeCoerce)
 import           Data.Default
 import           Data.Maybe
-import           Data.Text (Text)
+import           Data.JSString as S (pack, unpack)
+import           Data.JSString.Text as S (textToJSString,textFromJSRef)
+import           Data.Text as Text (Text, unpack)
 import           Data.Typeable
 
 import           System.IO (fixIO)
+
+import Data.Coerce
+import Unsafe.Coerce
+
+default (JSString)
+
 
 type EventType = Text
 type Selector  = Text
@@ -230,126 +244,124 @@ instance Default AjaxSettings where
   def = AjaxSettings "application/x-www-form-urlencoded; charset=UTF-8" True False GET
 
 instance ToJSRef AjaxSettings where
-  toJSRef (AjaxSettings ct cache ifMod method) = do
-    o <- newObj
-    let (.=) :: Text -> JSRef a -> IO ()
-        p .= v = F.setProp p v o
-    "method"      .= toJSString method
+  toJSRef o = fmap jsref (ajaxSettingsToObject o)
+
+ajaxSettingsToObject :: AjaxSettings -> IO Object
+ajaxSettingsToObject (AjaxSettings ct cache ifMod method) = do
+    o <- Obj.create
+    let (.=) :: JSString -> JSRef -> IO ()
+        p .= v = Obj.setProp p v o
+    "method"      .= (jsref . S.pack . show) method
     "ifModified"  .= toJSBool ifMod
     "cache"       .= toJSBool cache
-    "contentType" .= toJSString ct
-    "dataType"    .= ("text" :: JSString)
+    "contentType" .= (jsref . S.pack . Text.unpack) ct
+    "dataType"    .= jsref ("text" :: JSString)
     return o
-
-instance ToJSString Method where
-  toJSString GET    = "GET"
-  toJSString POST   = "POST"
-  toJSString PUT    = "PUT"
-  toJSString DELETE = "DELETE"
 
 ajax :: Text -> [(Text,Text)] -> AjaxSettings -> IO AjaxResult
 ajax url d s = do
-  o <- newObj
-  forM_ d (\(k,v) -> F.setProp k (toJSString v) o)
-  os <- toJSRef s
-  F.setProp ("data"::Text) o os
-  arr <- jq_ajax (toJSString url) os
-  dat <- F.getProp ("data"::Text) arr
-  let d = if isNull dat then Nothing else Just (fromJSString dat)
-  status <- fromMaybe 0 <$> (fromJSRef =<< F.getProp ("status"::Text) arr)
-  return (AjaxResult status d)
+  o <- Obj.create
+  forM_ d (\(k,v) -> Obj.setProp (textToJSString k) ((jsref . textToJSString) v) o)
+  os <- ajaxSettingsToObject s
+  Obj.setProp ("data"::JSString) (jsref o) os
+  arrjs <- jq_ajax (textToJSString url) (jsref os)
+  let Just arr = unsafeCoerce arrjs
+  dat <- Obj.getProp ("data"::JSString) arr
+  let d = textFromJSRef dat -- if isNull dat then Nothing else Just (S.unpack dat)
+  status <- fromMaybe 0 <$> (fromJSRef =<< Obj.getProp "status" arr)
+  return (AjaxResult status (Just d))
 
 data HandlerSettings = HandlerSettings { hsPreventDefault           :: Bool
                                        , hsStopPropagation          :: Bool
                                        , hsStopImmediatePropagation :: Bool
                                        , hsSynchronous              :: Bool
                                        , hsDescendantFilter         :: Maybe Selector
-                                       , hsHandlerData              :: Maybe (JSRef ())
+                                       , hsHandlerData              :: Maybe JSRef
                                        }
 
-convertHandlerSettings :: HandlerSettings -> (Bool, Bool, Bool, JSString, JSRef ())
+convertHandlerSettings :: HandlerSettings -> (Bool, Bool, Bool, JSString, JSRef)
 convertHandlerSettings (HandlerSettings pd sp sip _ ds hd) =
-  (pd, sp, sip, maybe jsNull toJSString ds, fromMaybe jsNull hd)
+  (pd, sp, sip, maybe ("" :: JSString) textToJSString ds, fromMaybe jsNull hd)
 
 instance Default HandlerSettings where
   def = HandlerSettings False False False True Nothing Nothing
 
-addClass :: Text -> JQuery -> IO JQuery
-addClass c = jq_addClass (toJSString c)
+addClass :: JSString -> JQuery -> IO JQuery
+addClass c = jq_addClass c
 
-animate :: JSObject a -> JSObject b -> JQuery -> IO JQuery
-animate = jq_animate
+animate :: Object -> Object -> JQuery -> IO JQuery
+animate s t = jq_animate (jsref s) (jsref t)
 
-getAttr :: Text -> JQuery -> IO Text
-getAttr a jq = fromJSString <$> jq_getAttr (toJSString a) jq
+getAttr :: JSString -> JQuery -> IO JSString
+getAttr a jq = jq_getAttr a jq
 
-setAttr :: Text -> Text -> JQuery -> IO JQuery
-setAttr a v = jq_setAttr (toJSString a) (toJSString v)
+setAttr :: JSString -> JSString -> JQuery -> IO JQuery
+setAttr a v = jq_setAttr a v
 
-hasClass :: Text -> JQuery -> IO Bool
-hasClass c jq = jq_hasClass (toJSString c) jq
+hasClass :: JSString -> JQuery -> IO Bool
+hasClass c jq = jq_hasClass c jq
 
-getHtml :: JQuery -> IO Text
-getHtml jq = fromJSString <$> jq_getHtml jq
+getHtml :: JQuery -> IO JSString
+getHtml jq = jq_getHtml jq
 
-setHtml :: Text -> JQuery -> IO JQuery
-setHtml t = jq_setHtml (toJSString t)
+setHtml :: JSString -> JQuery -> IO JQuery
+setHtml t = jq_setHtml t
 
-getProp :: Text -> JQuery -> IO Text
-getProp p jq = fromJSString <$> jq_getProp (toJSString p) jq
+-- getProp :: JSString -> JQuery -> IO JSString
+-- getProp p jq = jq_getProp p jq
 
 -- fixme value can be Boolean or Number
-setProp :: Text -> Text -> JQuery -> IO JQuery
-setProp p v = jq_setProp (toJSString p) (toJSString v)
+-- setProp :: JSString -> JSString -> JQuery -> IO JQuery
+-- setProp p v = jq_setProp p v
 
-removeAttr :: Text -> JQuery -> IO JQuery
-removeAttr a = jq_removeAttr (toJSString a)
+removeAttr :: JSString -> JQuery -> IO JQuery
+removeAttr a = jq_removeAttr a
 
-removeClass :: Text -> JQuery -> IO JQuery
-removeClass c = jq_removeClass (toJSString c)
+removeClass :: JSString -> JQuery -> IO JQuery
+removeClass c = jq_removeClass c
 
-removeProp :: Text -> JQuery -> IO JQuery
-removeProp p = jq_removeProp (toJSString p)
+removeProp :: JSString -> JQuery -> IO JQuery
+removeProp p = jq_removeProp p
 
--- toggleClass :: Text -> JQuery -> IO JQuery
--- toggleClass c = jq_toggleClass (toJSString c)
+-- toggleClass :: JSString -> JQuery -> IO JQuery
+-- toggleClass c = jq_toggleClass (S.pack c)
 
-getVal :: JQuery -> IO Text
-getVal jq = fromJSString <$> jq_getVal jq
+getVal :: JQuery -> IO JSString
+getVal jq = jq_getVal jq
 
-setVal :: Text -> JQuery -> IO JQuery
-setVal v = jq_setVal (toJSString v)
+setVal :: JSString -> JQuery -> IO JQuery
+setVal v = jq_setVal v
 
-getText :: JQuery -> IO Text
-getText jq = fromJSString <$> jq_getText jq
+getText :: JQuery -> IO JSString
+getText jq = jq_getText jq
 
-setText :: Text -> JQuery -> IO JQuery
-setText t = jq_setText (toJSString t)
+setText :: JSString -> JQuery -> IO JQuery
+setText t = jq_setText t
 
 holdReady :: Bool -> IO ()
 holdReady b = jq_holdReady b
 
 selectElement :: IsElement e => e -> IO JQuery
-selectElement e = jq_selectElement (unElement (toElement e))
+selectElement e = jq_selectElement (toElement e)
 
-selectObject :: JSObject a -> IO JQuery
-selectObject a = jq_selectObject (castRef a)
+selectObject :: Object -> IO JQuery
+selectObject a = jq_selectObject (jsref a)
 
-select :: Text -> IO JQuery
-select q = jq_select (toJSString q)
+select :: JSString -> IO JQuery
+select q = jq_select q
 
 selectEmpty :: IO JQuery
 selectEmpty = jq_selectEmpty
 
--- :: Text -> Either JQuery JSObject -> IO JQuery ?
-selectWithContext :: Text -> JSObject a -> IO JQuery
-selectWithContext t o = jq_selectWithContext (toJSString t) (castRef o)
+-- :: Text -> Either JQuery Object -> IO JQuery ?
+selectWithContext :: JSString -> Object -> IO JQuery
+selectWithContext t o = jq_selectWithContext t (jsref o)
 
-getCss :: Text -> JQuery -> IO Text
-getCss t jq = fromJSString <$> jq_getCss (toJSString t) jq
+getCss :: JSString -> JQuery -> IO JSString
+getCss t jq = jq_getCss t jq
 
-setCss :: Text -> Text -> JQuery -> IO JQuery
-setCss k v = jq_setCss (toJSString k) (toJSString v)
+setCss :: JSString -> JSString -> JQuery -> IO JQuery
+setCss k v = jq_setCss k v
 
 getHeight :: JQuery -> IO Double
 getHeight = jq_getHeight
@@ -436,32 +448,32 @@ mouseup a = on a "mouseup"
 on :: (Event -> IO ()) -> EventType -> HandlerSettings -> JQuery -> IO (IO ())
 on a et hs jq = do
   cb <- if hsSynchronous hs
-          then F.syncCallback1 F.AlwaysRetain True a
-          else F.asyncCallback1 F.AlwaysRetain a
+          then Cb.syncCallback1 ContinueAsync (a . Event)
+          else Cb.asyncCallback1 (a . Event)
   jq_on cb et' ds hd sp sip pd jq
-  return (jq_off cb et' ds jq >> F.release cb)
+  return (jq_off cb et' ds jq >> Cb.releaseCallback cb)
     where
-      et'                   = toJSString et
+      et'                   = textToJSString et
       (pd, sp, sip, ds, hd) = convertHandlerSettings hs
 
 one :: (Event -> IO ()) -> EventType -> HandlerSettings -> JQuery -> IO (IO ())
 one a et hs jq = do
   cb <- fixIO $ \cb ->
-      let a' = \e -> F.release cb >> a e
+      let a' = \e -> Cb.releaseCallback cb >> a e
       in if hsSynchronous hs
-            then F.syncCallback1 F.AlwaysRetain True a
-            else F.asyncCallback1 F.AlwaysRetain a
+            then Cb.syncCallback1 ContinueAsync (a . Event)
+            else Cb.asyncCallback1 (a . Event)
   jq_one cb et' ds hd sp sip pd jq
-  return (jq_off cb et' ds jq >> F.release cb)
+  return (jq_off cb et' ds jq >> Cb.releaseCallback cb)
     where
-      et'                   = toJSString et
+      et'                   = textToJSString et
       (pd, sp, sip, ds, hd) = convertHandlerSettings hs
 
 trigger :: EventType -> JQuery -> IO ()
-trigger et jq = jq_trigger (toJSString et) jq
+trigger et jq = jq_trigger (textToJSString et) jq
 
 triggerHandler :: EventType -> JQuery -> IO ()
-triggerHandler et jq = jq_triggerHandler (toJSString et) jq
+triggerHandler et jq = jq_triggerHandler (textToJSString et) jq
 
 delegateTarget :: Event -> IO Element
 delegateTarget ev = Element <$> jq_delegateTarget ev
@@ -475,8 +487,8 @@ isImmediatePropagationStopped e = jq_isImmediatePropagationStopped e
 isPropagationStopped :: Event -> IO Bool
 isPropagationStopped e = jq_isPropagationStopped e
 
-namespace :: Event -> IO Text
-namespace e = fromJSString <$> jq_namespace e
+namespace :: Event -> IO JSString
+namespace e = jq_namespace e
 
 pageX :: Event -> IO Double
 pageX = jq_pageX
@@ -499,8 +511,8 @@ target ev = Element <$> jq_target ev
 timeStamp :: Event -> IO Double
 timeStamp = jq_timeStamp
 
-eventType :: Event -> IO Text
-eventType e = fromJSString <$> jq_eventType e
+eventType :: Event -> IO JSString
+eventType e = jq_eventType e
 
 which :: Event -> IO Int
 which = jq_eventWhich
@@ -532,41 +544,41 @@ keyup a = on a "keyup"
 keypress :: (Event -> IO ()) -> HandlerSettings -> JQuery -> IO (IO ())
 keypress a = on a "keypress"
 
-after :: Text -> JQuery -> IO JQuery
-after h jq = jq_after (castRef $ toJSString h) jq
+after :: JSString -> JQuery -> IO JQuery
+after = jq_after
 
 afterJQuery :: JQuery -> JQuery -> IO JQuery
-afterJQuery j jq = jq_after (castRef j) jq
+afterJQuery = jq_after_jq
 
 afterElem :: IsElement e => e -> JQuery -> IO JQuery
-afterElem e jq = jq_after (castRef . unElement $ toElement e) jq
+afterElem e jq = jq_after_jq (JQuery . unElement $ toElement e) jq
 
-append :: Text -> JQuery -> IO JQuery
-append h jq = jq_append (castRef $ toJSString h) jq
+append :: JSString -> JQuery -> IO JQuery
+append h jq = jq_append h jq
 
 appendJQuery :: JQuery -> JQuery -> IO JQuery
-appendJQuery j jq = jq_append (castRef j) jq
+appendJQuery j jq = jq_append_jq j jq
 
 appendElem :: IsElement e => e -> JQuery -> IO JQuery
-appendElem e jq = jq_append (castRef . unElement $ toElement e) jq
+appendElem e jq = jq_append_jq (JQuery . unElement $ toElement e) jq
 
-appendTo :: Text -> JQuery -> IO JQuery
-appendTo h jq = jq_appendTo (castRef $ toJSString h) jq
+appendTo :: JSString -> JQuery -> IO JQuery
+appendTo h jq = jq_appendTo h jq
 
 appendToJQuery :: JQuery -> JQuery -> IO JQuery
-appendToJQuery j jq = jq_appendTo (castRef j) jq
+appendToJQuery j jq = jq_appendTo_jq j jq
 
 appendToElem :: IsElement e => e -> JQuery -> IO JQuery
-appendToElem e jq = jq_appendTo (castRef . unElement $ toElement e) jq
+appendToElem e jq = jq_appendTo_jq (JQuery . unElement $ toElement e) jq
 
-before :: Text -> JQuery -> IO JQuery
-before h jq = jq_before (castRef $ toJSString h) jq
+before :: JSString -> JQuery -> IO JQuery
+before h jq = jq_before h jq
 
 beforeJQuery :: JQuery -> JQuery -> IO JQuery
-beforeJQuery j jq = jq_before (castRef j) jq
+beforeJQuery j jq = jq_before_jq j jq
 
 beforeElem :: IsElement e => e -> JQuery -> IO JQuery
-beforeElem e jq = jq_before (castRef . unElement $ toElement e) jq
+beforeElem e jq = jq_before_jq (JQuery . unElement $ toElement e) jq
 
 data CloneType = WithoutDataAndEvents
                | WithDataAndEvents
@@ -578,115 +590,115 @@ clone WithDataAndEvents     = jq_clone True  False
 clone DeepWithDataAndEvents = jq_clone True  True
 
 detach :: JQuery -> IO JQuery
-detach = jq_detach jsNull
+detach = jq_detach 
 
 detachSelector :: Selector -> JQuery -> IO JQuery
-detachSelector s = jq_detach (toJSString s)
+detachSelector s = jq_detachSelector (textToJSString s)
 
 empty :: JQuery -> IO JQuery
 empty = jq_empty
 
-insertAfter :: Text -> JQuery -> IO JQuery
-insertAfter h jq = jq_insertAfter (castRef $ toJSString h) jq
+insertAfter :: JSString -> JQuery -> IO JQuery
+insertAfter = jq_insertAfter
 
 insertAfterJQuery :: JQuery -> JQuery -> IO JQuery
-insertAfterJQuery j jq = jq_insertAfter (castRef j) jq
+insertAfterJQuery = jq_insertAfter_jq
 
 insertAfterElem :: IsElement e => e -> JQuery -> IO JQuery
-insertAfterElem e jq = jq_insertAfter (castRef . unElement $ toElement e) jq
+insertAfterElem e jq = jq_insertAfter_jq (JQuery . unElement $ toElement e) jq
 
-insertBefore :: Text -> JQuery -> IO JQuery
-insertBefore h jq = jq_insertBefore (castRef $ toJSString h) jq
+insertBefore :: JSString -> JQuery -> IO JQuery
+insertBefore = jq_insertBefore
 
 insertBeforeJQuery :: JQuery -> JQuery -> IO JQuery
-insertBeforeJQuery j jq = jq_insertBefore (castRef j) jq
+insertBeforeJQuery = jq_insertBefore_jq
 
 insertBeforeElem :: IsElement e => e -> JQuery -> IO JQuery
-insertBeforeElem e jq = jq_insertBefore (castRef . unElement $ toElement e) jq
+insertBeforeElem e jq = jq_insertBefore_jq (JQuery . unElement $ toElement e) jq
 
-prepend :: Text -> JQuery -> IO JQuery
-prepend h jq = jq_prepend (castRef $ toJSString h) jq
+prepend :: JSString -> JQuery -> IO JQuery
+prepend = jq_prepend
 
 prependJQuery :: JQuery -> JQuery -> IO JQuery
-prependJQuery j jq = jq_prepend (castRef j) jq
+prependJQuery = jq_prepend_jq
 
 prependElem :: IsElement e => e -> JQuery -> IO JQuery
-prependElem e jq = jq_prepend (castRef . unElement $ toElement e) jq
+prependElem e jq = jq_prepend_jq (JQuery . unElement $ toElement e) jq
 
-prependTo :: Text -> JQuery -> IO JQuery
-prependTo h jq = jq_prependTo (castRef $ toJSString h) jq
+prependTo :: JSString -> JQuery -> IO JQuery
+prependTo = jq_prependTo
 
 prependToJQuery :: JQuery -> JQuery -> IO JQuery
-prependToJQuery j jq = jq_prependTo (castRef j) jq
+prependToJQuery = jq_prependTo_jq
 
 prependToElem :: IsElement e => e -> JQuery -> IO JQuery
-prependToElem e jq = jq_prependTo (castRef . unElement $ toElement e) jq
+prependToElem e jq = jq_prependTo_jq (JQuery . unElement $ toElement e) jq
 
 remove :: JQuery -> IO JQuery
-remove = jq_remove jsNull
+remove = jq_remove
 
 removeSelector :: Selector -> JQuery -> IO JQuery
-removeSelector s = jq_remove (toJSString s)
+removeSelector s = jq_removeSelector (textToJSString s)
 
-replaceAll :: Text -> JQuery -> IO JQuery
-replaceAll h jq = jq_replaceAll (castRef $ toJSString h) jq
+replaceAll :: JSString -> JQuery -> IO JQuery
+replaceAll h jq = jq_replaceAll h jq
 
 replaceAllJQuery :: JQuery -> JQuery -> IO JQuery
-replaceAllJQuery j jq = jq_replaceAll (castRef j) jq
+replaceAllJQuery = jq_replaceAll_jq
 
 replaceAllElem :: IsElement e => e -> JQuery -> IO JQuery
-replaceAllElem e jq = jq_replaceAll (castRef . unElement $ toElement e) jq
+replaceAllElem e jq = jq_replaceAll_jq (JQuery . unElement $ toElement e) jq
 
-replaceWith :: Text -> JQuery -> IO JQuery
-replaceWith h jq = jq_replaceWith (castRef $ toJSString h) jq
+replaceWith :: JSString -> JQuery -> IO JQuery
+replaceWith = jq_replaceWith
 
 replaceWithJQuery :: JQuery -> JQuery -> IO JQuery
-replaceWithJQuery j jq = jq_replaceWith (castRef j) jq
+replaceWithJQuery = jq_replaceWith_jq
 
 replaceWithElem :: IsElement e => e -> JQuery -> IO JQuery
-replaceWithElem e jq = jq_replaceWith (castRef . unElement $ toElement e) jq
+replaceWithElem e jq = jq_replaceWith_jq (JQuery . unElement $ toElement e) jq
 
 unwrap :: JQuery -> IO JQuery
 unwrap = jq_unwrap
 
-wrap :: Text -> JQuery -> IO JQuery
-wrap h jq = jq_wrap (castRef $ toJSString h) jq
+wrap :: JSString -> JQuery -> IO JQuery
+wrap = jq_wrap
 
 wrapJQuery :: JQuery -> JQuery -> IO JQuery
-wrapJQuery j jq = jq_wrap (castRef j) jq
+wrapJQuery = jq_wrap_jq
 
 wrapElem :: IsElement e => e -> JQuery -> IO JQuery
-wrapElem e jq = jq_wrap (castRef . unElement $ toElement e) jq
+wrapElem e jq = jq_wrap_jq (JQuery . unElement $ toElement e) jq
 
-wrapAll :: Text -> JQuery -> IO JQuery
-wrapAll h jq = jq_wrapAll (castRef $ toJSString h) jq
+wrapAll :: Selector -> JQuery -> IO JQuery
+wrapAll s = jq_wrapAll (textToJSString s)
 
 wrapAllJQuery :: JQuery -> JQuery -> IO JQuery
-wrapAllJQuery j jq = jq_wrapAll (castRef j) jq
+wrapAllJQuery = jq_wrapAll_jq
 
 wrapAllElem :: IsElement e => e -> JQuery -> IO JQuery
-wrapAllElem e jq = jq_wrapAll (castRef . unElement $ toElement e) jq
+wrapAllElem e jq = jq_wrapAll_jq (JQuery . unElement $ toElement e) jq
 
-wrapInner :: Text -> JQuery -> IO JQuery
-wrapInner h jq = jq_wrapInner (castRef $ toJSString h) jq
+wrapInner :: JSString -> JQuery -> IO JQuery
+wrapInner = jq_wrapInner
 
 wrapInnerJQuery :: JQuery -> JQuery -> IO JQuery
-wrapInnerJQuery j jq = jq_wrapInner (castRef j) jq
+wrapInnerJQuery = jq_wrapInner_jq
 
 wrapInnerElem :: IsElement e => e -> JQuery -> IO JQuery
-wrapInnerElem e jq = jq_wrapInner (castRef . unElement $ toElement e) jq
+wrapInnerElem e jq = jq_wrapInner_jq (JQuery . unElement $ toElement e) jq
 
 addSelector :: Selector -> JQuery -> IO JQuery
-addSelector s jq = jq_add (castRef $ toJSString s) jq
+addSelector s = jq_add (textToJSString s)
 
 addElement :: IsElement e => e -> JQuery -> IO JQuery
-addElement e jq = jq_add (castRef . unElement $ toElement e) jq
+addElement e jq = jq_add_jq (JQuery . unElement $ toElement e) jq
 
-addHtml :: Text -> JQuery -> IO JQuery
-addHtml h jq = jq_add (castRef $ toJSString h) jq
+addHtml :: JSString -> JQuery -> IO JQuery
+addHtml = jq_add
 
 add :: JQuery -> JQuery -> IO JQuery
-add j jq = jq_add (castRef j) jq
+add = jq_add_jq
 
 -- addSelectorWithContext :: Selector -> JQuery -> JQuery -> IO JQuery
 -- addSelectorWithContext = undefined
@@ -695,22 +707,22 @@ andSelf :: JQuery -> IO JQuery
 andSelf = jq_andSelf
 
 children :: JQuery -> IO JQuery
-children = jq_children jsNull
+children = jq_children ("" :: JSString)
 
 childrenMatching :: Selector -> JQuery -> IO JQuery
-childrenMatching s = jq_children (toJSString s)
+childrenMatching s = jq_children (textToJSString s)
 
 closestSelector :: Selector -> JQuery -> IO JQuery
-closestSelector s jq = jq_closest (castRef $ toJSString s) jq
+closestSelector s = jq_closest (textToJSString s)
 
 -- closestWithContext :: Selector -> Selector -> JQuery -> IO JQuery
 -- closestWithContext = undefined
 
 closest :: JQuery -> JQuery -> IO JQuery
-closest j jq = jq_closest (castRef j) jq
+closest = jq_closest_jq
 
 closestElement :: IsElement e => e -> JQuery -> IO JQuery
-closestElement e jq = jq_closest (castRef . unElement $ toElement e) jq
+closestElement e jq = jq_closest_jq (JQuery . unElement $ toElement e) jq
 
 contents :: JQuery -> IO JQuery
 contents = jq_contents
@@ -726,118 +738,118 @@ eq :: Int -> JQuery -> IO JQuery
 eq = jq_eq
 
 filter :: Selector -> JQuery -> IO JQuery
-filter s = jq_filter (castRef $ toJSString s)
-
-filterElement :: IsElement e => e -> JQuery -> IO JQuery
-filterElement e = jq_filter (castRef . unElement $ toElement e)
+filter s = jq_filter (textToJSString s)
 
 filterJQuery :: JQuery -> JQuery -> IO JQuery
-filterJQuery j = jq_filter (castRef j)
+filterJQuery = jq_filter_jq
+
+filterElement :: IsElement e => e -> JQuery -> IO JQuery
+filterElement e = jq_filter_jq (JQuery . unElement $ toElement e)
 
 find :: Selector -> JQuery -> IO JQuery
-find s = jq_find (castRef $ toJSString s)
+find s = jq_find (textToJSString s)
 
 findJQuery :: JQuery -> JQuery -> IO JQuery
-findJQuery j = jq_find (castRef j)
+findJQuery = jq_find_jq
 
 findElement :: IsElement e => e -> JQuery -> IO JQuery
-findElement e = jq_find (castRef . unElement $ toElement e)
+findElement e = jq_find_jq (JQuery . unElement $ toElement e)
 
 first :: JQuery -> IO JQuery
 first = jq_first
 
 has :: Selector -> JQuery -> IO JQuery
-has s = jq_has (castRef $ toJSString s)
+has s = jq_has (textToJSString s)
 
 hasElement :: IsElement e => e -> JQuery -> IO JQuery
-hasElement e = jq_has (castRef . unElement $ toElement e)
+hasElement e = jq_has_jq (JQuery . unElement $ toElement e)
 
 is :: Selector -> JQuery -> IO Bool
-is s = jq_is (castRef $ toJSString s)
+is s = jq_is  (textToJSString s)
 
 isJQuery :: JQuery -> JQuery -> IO Bool
-isJQuery j = jq_is (castRef j)
+isJQuery = jq_is_jq
 
 isElement :: IsElement e => e -> JQuery -> IO Bool
-isElement e = jq_is (castRef . unElement $ toElement e)
+isElement e = jq_is_jq (JQuery . unElement $ toElement e)
 
 last :: JQuery -> IO JQuery
 last = jq_last
 
 next :: JQuery -> IO JQuery
-next = jq_next jsNull
+next = jq_next
 
 nextSelector :: Selector -> JQuery -> IO JQuery
-nextSelector s = jq_next (toJSString s)
+nextSelector s = jq_nextSelector (textToJSString s)
 
 nextAll :: JQuery -> IO JQuery
-nextAll = jq_nextAll jsNull
+nextAll = jq_nextAll
 
 nextAllSelector :: Selector -> JQuery -> IO JQuery
-nextAllSelector s = jq_nextAll (toJSString s)
+nextAllSelector s = jq_nextAllSelector (textToJSString s)
 
 nextUntil :: Selector -> Maybe Selector -> JQuery -> IO JQuery
-nextUntil s mf = jq_nextUntil (castRef $ toJSString s) (maybe jsNull toJSString mf)
+nextUntil s mf = jq_nextUntil (textToJSString s) (maybe "" textToJSString mf)
 
 nextUntilElement :: IsElement e => e -> Maybe Selector -> JQuery -> IO JQuery
-nextUntilElement e mf = jq_nextUntil (castRef . unElement $ toElement e) (maybe jsNull toJSString mf)
+nextUntilElement e mf = jq_nextUntil_jq (JQuery . unElement $ toElement e) (maybe "" textToJSString mf)
 
 not :: Selector -> JQuery -> IO JQuery
-not s = jq_not (castRef $ toJSString s)
+not s = jq_not (textToJSString s)
+
+notJQuery :: JQuery -> JQuery -> IO JQuery
+notJQuery = jq_not_jq
 
 notElement :: IsElement e => e -> JQuery -> IO JQuery
-notElement e = jq_not (castRef . unElement $ toElement e)
+notElement e = jq_not_jq (JQuery . unElement $ toElement e)
 
 -- notElements :: [Element] -> JQuery -> IO JQuery
 -- notElements = jq_notElements
-
-notJQuery :: JQuery -> JQuery -> IO JQuery
-notJQuery j = jq_not (castRef j)
 
 offsetParent :: JQuery -> IO JQuery
 offsetParent = jq_offsetParent
 
 parent :: JQuery -> IO JQuery
-parent = jq_parent jsNull
+parent = jq_parent ("" :: JSString)
 
-parentSelector :: String -> JQuery -> IO JQuery
-parentSelector s = jq_parent (toJSString s)
+parentSelector :: Selector -> JQuery -> IO JQuery
+parentSelector s = jq_parent (textToJSString s)
 
 parents :: JQuery -> IO JQuery
-parents = jq_parents jsNull
+parents = jq_parents ("" :: JSString)
 
 parentsSelector :: Selector -> JQuery -> IO JQuery
-parentsSelector s = jq_parents (toJSString s)
+parentsSelector s = jq_parents (textToJSString s)
 
 parentsUntil :: Selector -> Maybe Selector -> JQuery -> IO JQuery
-parentsUntil s mf = jq_parentsUntil (castRef $ toJSString s) (maybe jsNull (castRef . toJSString) mf)
+parentsUntil s mf = jq_parentsUntil (textToJSString s) (maybe "" textToJSString mf)
 
 parentsUntilElement :: IsElement e => e -> Maybe Selector -> JQuery -> IO JQuery
-parentsUntilElement e mf = jq_parentsUntil (castRef . unElement $ toElement e) (maybe jsNull (castRef . toJSString) mf)
+parentsUntilElement e mf = jq_parentsUntil_jq (JQuery . unElement $ toElement e) (maybe "" textToJSString mf)
 
 prev :: JQuery -> IO JQuery
-prev = jq_prev jsNull
+prev = jq_prev ("" :: JSString)
 
 prevSelector :: Selector -> JQuery -> IO JQuery
-prevSelector s = jq_prev (toJSString s)
+prevSelector s = jq_prev (textToJSString s)
 
 prevAll :: JQuery -> IO JQuery
-prevAll = jq_prevAll jsNull
+prevAll = jq_prevAll
 
-prevAllSelector :: String -> JQuery -> IO JQuery
-prevAllSelector s = jq_prevAll (toJSString s)
+prevAllSelector :: Selector -> JQuery -> IO JQuery
+prevAllSelector s = jq_prevAllSelector (textToJSString s)
 
 prevUntil :: Selector -> Maybe Selector -> JQuery -> IO JQuery
-prevUntil s mf = jq_prevUntil (castRef $ toJSString s) (maybe jsNull toJSString mf)
+prevUntil s mf = jq_prevUntil (textToJSString s) (maybe "" textToJSString mf)
 
 prevUntilElement :: IsElement e => e -> Maybe Selector -> JQuery -> IO JQuery
-prevUntilElement e mf = jq_prevUntil (castRef . unElement $ toElement e) (maybe jsNull toJSString mf)
+prevUntilElement e mf = jq_prevUntil_jq (JQuery . unElement $ toElement e) (maybe "" textToJSString mf)
 
 siblings :: JQuery -> IO JQuery
-siblings = jq_siblings jsNull
+siblings = jq_siblings
 
 siblingsSelector :: Selector -> JQuery -> IO JQuery
-siblingsSelector s = jq_siblings (toJSString s)
+siblingsSelector s = jq_siblingsSelector (textToJSString s)
 
 slice :: Int -> JQuery -> IO JQuery
 slice = jq_slice

--- a/JavaScript/JQuery/Internal.hs
+++ b/JavaScript/JQuery/Internal.hs
@@ -2,21 +2,20 @@
 
 module JavaScript.JQuery.Internal where
 
-import GHCJS.Types
 import GHCJS.DOM.Types (Element(..))
 import GHCJS.Foreign
+import GHCJS.Foreign.Callback (Callback)
+import GHCJS.Nullable
+import GHCJS.Types
 
 import Control.Concurrent.MVar
 
-data JQuery_
-data Event_
-
-type JQuery = JSRef JQuery_
-type Event = JSRef Event_
+newtype JQuery = JQuery JSRef
+newtype Event = Event JSRef
 
 #ifdef ghcjs_HOST_OS
 foreign import javascript unsafe "$2.addClass($1)"       jq_addClass          :: JSString             -> JQuery -> IO JQuery
-foreign import javascript unsafe "$3.animate($1,$2)"     jq_animate           :: JSObject a -> JSObject b -> JQuery -> IO JQuery           
+foreign import javascript unsafe "$3.animate($1,$2)"     jq_animate           :: JSRef    -> JSRef    -> JQuery -> IO JQuery
 foreign import javascript unsafe "$2.attr($1)"           jq_getAttr           :: JSString             -> JQuery -> IO JSString
 foreign import javascript unsafe "$3.attr($1,$2)"        jq_setAttr           :: JSString -> JSString -> JQuery -> IO JQuery
 foreign import javascript unsafe "$2.hasClass($1)"       jq_hasClass          :: JSString             -> JQuery -> IO Bool
@@ -32,11 +31,11 @@ foreign import javascript unsafe "$2.val($1)"            jq_setVal            ::
 foreign import javascript unsafe "$1.text()"             jq_getText           ::                         JQuery -> IO JSString
 foreign import javascript unsafe "$2.text($1)"           jq_setText           :: JSString             -> JQuery -> IO JQuery
 foreign import javascript unsafe "jQuery.holdReady($1)"  jq_holdReady         :: Bool                           -> IO ()
-foreign import javascript unsafe "jQuery($1)"            jq_selectElement     :: JSRef Element                  -> IO JQuery
-foreign import javascript unsafe "jQuery($1)"            jq_selectObject      :: JSRef ()                       -> IO JQuery
+foreign import javascript unsafe "jQuery($1)"            jq_selectElement     :: Element                        -> IO JQuery
+foreign import javascript unsafe "jQuery($1)"            jq_selectObject      :: JSRef                          -> IO JQuery
 foreign import javascript unsafe "jQuery($1)"            jq_select            :: JSString                       -> IO JQuery
 foreign import javascript unsafe "jQuery()"              jq_selectEmpty       ::                                   IO JQuery
-foreign import javascript unsafe "jQuery($1,$2)"         jq_selectWithContext :: JSString -> JSRef ()           -> IO JQuery
+foreign import javascript unsafe "jQuery($1,$2)"         jq_selectWithContext :: JSString -> JSRef              -> IO JQuery
 foreign import javascript unsafe "$2.css($1)"            jq_getCss            :: JSString             -> JQuery -> IO JSString
 foreign import javascript unsafe "$3.css($1,$2)"         jq_setCss            :: JSString -> JSString -> JQuery -> IO JQuery
 foreign import javascript unsafe "$1.height()"           jq_getHeight         ::                         JQuery -> IO Double
@@ -56,7 +55,7 @@ foreign import javascript unsafe "$2.scrollTop($1)"      jq_setScrollTop      ::
 foreign import javascript unsafe "$2.stop($1)"           jq_stop              :: Bool                 -> JQuery -> IO JQuery
 foreign import javascript unsafe "$1.focus()"            jq_focus             ::                         JQuery -> IO JQuery
 
-foreign import javascript unsafe "jQuery($1.delegateTarget)"          jq_delegateTarget                :: Event -> IO (JSRef Element)
+foreign import javascript unsafe "jQuery($1.delegateTarget)"          jq_delegateTarget                :: Event -> IO JSRef -- Element
 foreign import javascript unsafe "$1.isDefaultPrevented()"            jq_isDefaultPrevented            :: Event -> IO Bool
 foreign import javascript unsafe "$1.isImmediatePropagationStopped()" jq_isImmediatePropagationStopped :: Event -> IO Bool
 foreign import javascript unsafe "$1.isPropagationStopped()"          jq_isPropagationStopped          :: Event -> IO Bool
@@ -66,55 +65,84 @@ foreign import javascript unsafe "$1.pageY"                           jq_pageY  
 foreign import javascript unsafe "$1.preventDefault()"                jq_preventDefault                :: Event -> IO ()
 foreign import javascript unsafe "$1.stopPropagation()"               jq_stopPropagation               :: Event -> IO ()
 foreign import javascript unsafe "$1.stopImmediatePropagation()"      jq_stopImmediatePropagation      :: Event -> IO ()
-foreign import javascript unsafe "$1.target"                          jq_target                        :: Event -> IO (JSRef Element)
+foreign import javascript unsafe "$1.target"                          jq_target                        :: Event -> IO JSRef -- Element
 foreign import javascript unsafe "$1.timeStamp"                       jq_timeStamp                     :: Event -> IO Double
 foreign import javascript unsafe "$1.type"                            jq_eventType                     :: Event -> IO JSString
 foreign import javascript unsafe "$1.which"                           jq_eventWhich                    :: Event -> IO Int -- fixme might not exist?
 
-foreign import javascript unsafe "$2.after($1)"                       jq_after             :: JSRef ()             -> JQuery -> IO JQuery
-foreign import javascript unsafe "$2.append($1)"                      jq_append            :: JSRef ()             -> JQuery -> IO JQuery
-foreign import javascript unsafe "$2.appendTo($1)"                    jq_appendTo          :: JSRef ()             -> JQuery -> IO JQuery
-foreign import javascript unsafe "$2.before($1)"                      jq_before            :: JSRef ()             -> JQuery -> IO JQuery
+foreign import javascript unsafe "$2.after($1)"                       jq_after             :: JSString             -> JQuery -> IO JQuery
+foreign import javascript unsafe "$2.after($1)"                       jq_after_jq          :: JQuery               -> JQuery -> IO JQuery
+foreign import javascript unsafe "$2.append($1)"                      jq_append            :: JSString             -> JQuery -> IO JQuery
+foreign import javascript unsafe "$2.append($1)"                      jq_append_jq         :: JQuery               -> JQuery -> IO JQuery
+foreign import javascript unsafe "$2.appendTo($1)"                    jq_appendTo          :: JSString             -> JQuery -> IO JQuery
+foreign import javascript unsafe "$2.appendTo($1)"                    jq_appendTo_jq       :: JQuery               -> JQuery -> IO JQuery
+foreign import javascript unsafe "$2.before($1)"                      jq_before            :: JSString             -> JQuery -> IO JQuery
+foreign import javascript unsafe "$2.before($1)"                      jq_before_jq         :: JQuery               -> JQuery -> IO JQuery
 foreign import javascript unsafe "$3.clone($1,$2)"                    jq_clone             :: Bool   -> Bool       -> JQuery -> IO JQuery
-foreign import javascript unsafe "$2.detach($1)"                      jq_detach            :: JSString             -> JQuery -> IO JQuery
+foreign import javascript unsafe "$1.detach()"                        jq_detach            ::                         JQuery -> IO JQuery
+foreign import javascript unsafe "$2.detach($1)"                      jq_detachSelector    :: JSString             -> JQuery -> IO JQuery
 foreign import javascript unsafe "$1.empty()"                         jq_empty             ::                         JQuery -> IO JQuery
-foreign import javascript unsafe "$2.insertAfter($1)"                 jq_insertAfter       :: JSRef ()             -> JQuery -> IO JQuery
-foreign import javascript unsafe "$2.insertBefore($1)"                jq_insertBefore      :: JSRef ()             -> JQuery -> IO JQuery
-foreign import javascript unsafe "$2.prepend($1)"                     jq_prepend           :: JSRef ()             -> JQuery -> IO JQuery
-foreign import javascript unsafe "$2.prependTo($1)"                   jq_prependTo         :: JSRef ()             -> JQuery -> IO JQuery
-foreign import javascript unsafe "$2.remove($1)"                      jq_remove            :: JSString             -> JQuery -> IO JQuery
-foreign import javascript unsafe "$2.replaceAll($1)"                  jq_replaceAll        :: JSRef ()             -> JQuery -> IO JQuery
-foreign import javascript unsafe "$2.replaceWith($1)"                 jq_replaceWith       :: JSRef ()             -> JQuery -> IO JQuery
+foreign import javascript unsafe "$2.insertAfter($1)"                 jq_insertAfter       :: JSString             -> JQuery -> IO JQuery
+foreign import javascript unsafe "$2.insertAfter($1)"                 jq_insertAfter_jq    :: JQuery               -> JQuery -> IO JQuery
+foreign import javascript unsafe "$2.insertBefore($1)"                jq_insertBefore      :: JSString             -> JQuery -> IO JQuery
+foreign import javascript unsafe "$2.insertBefore($1)"                jq_insertBefore_jq   :: JQuery               -> JQuery -> IO JQuery
+foreign import javascript unsafe "$2.prepend($1)"                     jq_prepend           :: JSString             -> JQuery -> IO JQuery
+foreign import javascript unsafe "$2.prepend($1)"                     jq_prepend_jq        :: JQuery               -> JQuery -> IO JQuery
+foreign import javascript unsafe "$2.prependTo($1)"                   jq_prependTo         :: JSString             -> JQuery -> IO JQuery
+foreign import javascript unsafe "$2.prependTo($1)"                   jq_prependTo_jq      :: JQuery               -> JQuery -> IO JQuery
+foreign import javascript unsafe "$1.remove()"                        jq_remove            ::                         JQuery -> IO JQuery
+foreign import javascript unsafe "$2.remove($1)"                      jq_removeSelector    :: JSString             -> JQuery -> IO JQuery
+foreign import javascript unsafe "$2.replaceAll($1)"                  jq_replaceAll        :: JSString             -> JQuery -> IO JQuery
+foreign import javascript unsafe "$2.replaceAll($1)"                  jq_replaceAll_jq     :: JQuery               -> JQuery -> IO JQuery
+foreign import javascript unsafe "$2.replaceWith($1)"                 jq_replaceWith       :: JSString             -> JQuery -> IO JQuery
+foreign import javascript unsafe "$2.replaceWith($1)"                 jq_replaceWith_jq    :: JQuery               -> JQuery -> IO JQuery
 foreign import javascript unsafe "$1.unwrap()"                        jq_unwrap            ::                         JQuery -> IO JQuery
-foreign import javascript unsafe "$2.wrap($1)"                        jq_wrap              :: JSRef ()             -> JQuery -> IO JQuery
-foreign import javascript unsafe "$2.wrapAll($1)"                     jq_wrapAll           :: JSRef ()             -> JQuery -> IO JQuery
-foreign import javascript unsafe "$2.wrapInner($1)"                   jq_wrapInner         :: JSRef ()             -> JQuery -> IO JQuery
-foreign import javascript unsafe "$2.add($1)"                         jq_add               :: JSRef ()             -> JQuery -> IO JQuery
+foreign import javascript unsafe "$2.wrap($1)"                        jq_wrap              :: JSString             -> JQuery -> IO JQuery
+foreign import javascript unsafe "$2.wrap($1)"                        jq_wrap_jq           :: JQuery               -> JQuery -> IO JQuery
+foreign import javascript unsafe "$2.wrapAll($1)"                     jq_wrapAll           :: JSString             -> JQuery -> IO JQuery
+foreign import javascript unsafe "$2.wrapAll($1)"                     jq_wrapAll_jq        :: JQuery               -> JQuery -> IO JQuery
+foreign import javascript unsafe "$2.wrapInner($1)"                   jq_wrapInner         :: JSString             -> JQuery -> IO JQuery
+foreign import javascript unsafe "$2.wrapInner($1)"                   jq_wrapInner_jq      :: JQuery               -> JQuery -> IO JQuery
+foreign import javascript unsafe "$2.add($1)"                         jq_add               :: JSString             -> JQuery -> IO JQuery
+foreign import javascript unsafe "$2.add($1)"                         jq_add_jq            :: JQuery               -> JQuery -> IO JQuery
 foreign import javascript unsafe "$1.andSelf()"                       jq_andSelf           ::                         JQuery -> IO JQuery
 foreign import javascript unsafe "$2.children($1)"                    jq_children          :: JSString             -> JQuery -> IO JQuery
-foreign import javascript unsafe "$2.closest($1)"                     jq_closest           :: JSRef ()             -> JQuery -> IO JQuery
+foreign import javascript unsafe "$2.closest($1)"                     jq_closest           :: JSString             -> JQuery -> IO JQuery
+foreign import javascript unsafe "$2.closest($1)"                     jq_closest_jq        :: JQuery               -> JQuery -> IO JQuery
 
 foreign import javascript unsafe "$1.contents()"                      jq_contents          ::                         JQuery -> IO JQuery
 foreign import javascript unsafe "$1.end()"                           jq_end               ::                         JQuery -> IO JQuery
 foreign import javascript unsafe "$2.eq($1)"                          jq_eq                :: Int                  -> JQuery -> IO JQuery
-foreign import javascript unsafe "$2.filter($1)"                      jq_filter            :: JSRef ()             -> JQuery -> IO JQuery
-foreign import javascript unsafe "$2.find($1)"                        jq_find              :: JSRef ()             -> JQuery -> IO JQuery
+foreign import javascript unsafe "$2.filter($1)"                      jq_filter            :: JSString             -> JQuery -> IO JQuery
+foreign import javascript unsafe "$2.filter($1)"                      jq_filter_jq         :: JQuery               -> JQuery -> IO JQuery
+foreign import javascript unsafe "$2.find($1)"                        jq_find              :: JSString             -> JQuery -> IO JQuery
+foreign import javascript unsafe "$2.find($1)"                        jq_find_jq           :: JQuery               -> JQuery -> IO JQuery
 foreign import javascript unsafe "$1.first()"                         jq_first             ::                         JQuery -> IO JQuery
-foreign import javascript unsafe "$2.has($1)"                         jq_has               :: JSRef ()             -> JQuery -> IO JQuery
-foreign import javascript unsafe "$2.is($1)"                          jq_is                :: JSRef ()             -> JQuery -> IO Bool
+foreign import javascript unsafe "$2.has($1)"                         jq_has               :: JSString             -> JQuery -> IO JQuery
+foreign import javascript unsafe "$2.has($1)"                         jq_has_jq            :: JQuery               -> JQuery -> IO JQuery
+foreign import javascript unsafe "$2.is($1)"                          jq_is                :: JSString             -> JQuery -> IO Bool
+foreign import javascript unsafe "$2.is($1)"                          jq_is_jq             :: JQuery               -> JQuery -> IO Bool
 foreign import javascript unsafe "$1.last()"                          jq_last              ::                         JQuery -> IO JQuery
-foreign import javascript unsafe "$2.next($1)"                        jq_next              :: JSString             -> JQuery -> IO JQuery
-foreign import javascript unsafe "$2.nextAll($1)"                     jq_nextAll           :: JSString             -> JQuery -> IO JQuery
-foreign import javascript unsafe "$3.nextUntil($1,$2)"                jq_nextUntil         :: JSRef () -> JSString -> JQuery -> IO JQuery
-foreign import javascript unsafe "$2.not($1)"                         jq_not               :: JSRef ()             -> JQuery -> IO JQuery
+foreign import javascript unsafe "$1.next()"                          jq_next              ::                         JQuery -> IO JQuery
+foreign import javascript unsafe "$2.next($1)"                        jq_nextSelector      :: JSString             -> JQuery -> IO JQuery
+foreign import javascript unsafe "$1.nextAll()"                       jq_nextAll           ::                         JQuery -> IO JQuery
+foreign import javascript unsafe "$2.nextAll($1)"                     jq_nextAllSelector   :: JSString             -> JQuery -> IO JQuery
+foreign import javascript unsafe "$3.nextUntil($1,$2)"                jq_nextUntil         :: JSString -> JSString -> JQuery -> IO JQuery
+foreign import javascript unsafe "$3.nextUntil($1,$2)"                jq_nextUntil_jq      :: JQuery   -> JSString -> JQuery -> IO JQuery
+foreign import javascript unsafe "$2.not($1)"                         jq_not               :: JSString             -> JQuery -> IO JQuery
+foreign import javascript unsafe "$2.not($1)"                         jq_not_jq            :: JQuery               -> JQuery -> IO JQuery
 foreign import javascript unsafe "$1.offsetParent()"                  jq_offsetParent      ::                         JQuery -> IO JQuery
 foreign import javascript unsafe "$2.parent($1)"                      jq_parent            :: JSString             -> JQuery -> IO JQuery
 foreign import javascript unsafe "$2.parents($1)"                     jq_parents           :: JSString             -> JQuery -> IO JQuery
-foreign import javascript unsafe "$3.parentsUntil($1,$2)"             jq_parentsUntil      :: JSRef () -> JSString -> JQuery -> IO JQuery
+foreign import javascript unsafe "$3.parentsUntil($1,$2)"             jq_parentsUntil      :: JSString -> JSString -> JQuery -> IO JQuery
+foreign import javascript unsafe "$3.parentsUntil($1,$2)"             jq_parentsUntil_jq   :: JQuery   -> JSString -> JQuery -> IO JQuery
 foreign import javascript unsafe "$2.prev($1)"                        jq_prev              :: JSString             -> JQuery -> IO JQuery
-foreign import javascript unsafe "$2.prevAll($1)"                     jq_prevAll           :: JSString             -> JQuery -> IO JQuery
+foreign import javascript unsafe "$1.prevAll()"                       jq_prevAll           ::                         JQuery -> IO JQuery
+foreign import javascript unsafe "$1.prevAll($1)"                     jq_prevAllSelector   :: JSString             -> JQuery -> IO JQuery
 foreign import javascript unsafe "$3.prevUntil($1,$2)"                jq_prevUntil         :: JSString -> JSString -> JQuery -> IO JQuery
-foreign import javascript unsafe "$2.siblings($1)"                    jq_siblings          :: JSString             -> JQuery -> IO JQuery
+foreign import javascript unsafe "$3.prevUntil($1,$2)"                jq_prevUntil_jq      :: JQuery   -> JSString -> JQuery -> IO JQuery
+foreign import javascript unsafe "$1.siblings()"                      jq_siblings          ::                         JQuery -> IO JQuery
+foreign import javascript unsafe "$2.siblings($1)"                    jq_siblingsSelector  :: JSString             -> JQuery -> IO JQuery
 foreign import javascript unsafe "$2.slice($1)"                       jq_slice             :: Int                  -> JQuery -> IO JQuery
 foreign import javascript unsafe "$1.slice($1,$2)"                    jq_sliceFromTo       :: Int -> Int           -> JQuery -> IO JQuery
 
@@ -125,15 +153,15 @@ foreign import javascript interruptible "jQuery.ajax($1,$2).always(function(d,ts
                                     $c({ data: null, status: d.status });\
                                   }\
                                 });"
-  jq_ajax :: JSString
-          -> JSRef ajaxSettings
-          -> IO (JSRef ajaxResult)
+  jq_ajax :: JSString             -- ^ URL
+          -> JSRef                -- ^ Settings
+          -> IO JSRef             -- ^ Response
 
 foreign import javascript unsafe "$8.on($2, $3, $4, h$jquery_makeListener($1, $5, $6, $7))"
-  jq_on :: JSFun a                -- ^ callback
+  jq_on :: Callback a             -- ^ callback
         -> JSString               -- ^ event type
         -> JSString               -- ^ descendant selector
-        -> JSRef b                -- ^ data
+        -> JSRef                  -- ^ data
         -> Bool                   -- ^ stopPropagation
         -> Bool                   -- ^ stopImmediatePropagation
         -> Bool                   -- ^ preventDefault
@@ -141,10 +169,10 @@ foreign import javascript unsafe "$8.on($2, $3, $4, h$jquery_makeListener($1, $5
         -> IO ()
 
 foreign import javascript unsafe "$8.one($2, $3, $4, h$jquery_makeListener($1, $5, $6, $7))"
-  jq_one :: JSFun a                -- ^ callback
+  jq_one :: Callback a             -- ^ callback
          -> JSString               -- ^ event type
          -> JSString               -- ^ descendant selector
-         -> JSRef b                -- ^ data
+         -> JSRef                  -- ^ data
          -> Bool                   -- ^ stopPropagation
          -> Bool                   -- ^ stopImmediatePropagation
          -> Bool                   -- ^ preventDefault
@@ -152,7 +180,7 @@ foreign import javascript unsafe "$8.one($2, $3, $4, h$jquery_makeListener($1, $
          -> IO ()
 
 foreign import javascript unsafe "$4.off($2,$3,$1)"
-  jq_off :: JSFun a                -- ^ callback
+  jq_off :: Callback a             -- ^ callback
          -> JSString               -- ^ event type
          -> JSString               -- ^ descendant selector
          -> JQuery

--- a/ghcjs-jquery.cabal
+++ b/ghcjs-jquery.cabal
@@ -21,7 +21,7 @@ library
   build-depends:     base >= 4.7 && < 4.9,
                      data-default,
                      ghcjs-base,
-                     ghcjs-dom < 0.2,
+                     ghcjs-dom > 0.2,
                      text
 
   default-language:    Haskell2010


### PR DESCRIPTION
This commit compiles, but I have not attempted to link it with anything.

There are a bunch of issues I sorted through, and there are some clear improvements to be made, I think.

1) I left all the instances of Text, but I'm thinking they should be switched to JSString.
2) There are inconsistencies in the handling of JQuery arguments, largely because of the crazily flexible nature of their calling conventions. I think an actual type for Selector that could hold nothing, a string, a JSRef, or a JQuery object might be a good thing. The ffi decls could then be reduced by nearly half as would the more haskellish wrappers, and the resulting code would be easier to create and would look more like jquery.

But as I am moving away from all but the most minimal uses of jquery, I am not going to be doing this.

The most important thing I discovered along the way was the automatic unwrappping/wrapping of newtypes by the ffi. This made many of the jsref calls unnecessary. I havn'et fully understood all your proposals yet, but I don't remember this being highlighted. If you aren't aware of it, I think you should factor it in.

Hope this helps. Cliff
